### PR TITLE
ENH adding python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,3 +278,6 @@ Feedstock Maintainers
 * [@beckermr](https://github.com/beckermr/)
 * [@conda-forge/bot](https://github.com/conda-forge/bot/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+python:
+  - 3.5.* *_cpython


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added python 3.5 as instructed in #33.

Merge this PR to enable Python 3.5.



Here's a checklist to do before merging.
- [ ] Bump the build number if needed.

Fixes #33