### PR TITLE
[ci skip] adding user @beckermr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @conda-forge-daemon
+* @beckermr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,35 +2,36 @@
 {% set version = "0.10" %}
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+name: {{ name|lower }}
+version: {{ version }}
 
 source:
-  url: https://github.com/regro/cf-autotick-bot-test-package/archive/v{{ version }}.tar.gz
-  sha256: fbee5bfbdbac135794f5730c3382ed8ccb97c8ec76daa6da9ac3435be83cb5db
+url: https://github.com/regro/cf-autotick-bot-test-package/archive/v{{ version }}.tar.gz
+sha256: fbee5bfbdbac135794f5730c3382ed8ccb97c8ec76daa6da9ac3435be83cb5db
 
 build:
-  number: 2
-  skip: true  # [not linux64]
+number: 2
+skip: true  # [not linux64]
 
 requirements:
-  host:
-    - python
-    - pip
-  run:
-    - python
+host:
+- python
+- pip
+run:
+- python
 
 test:
-  commands:
-    - echo "works!"
+commands:
+- echo "works!"
 
 about:
-  home: https://github.com/regro/cf-scripts
-  license: BSD-3-Clause
-  license_family: BSD
-  license_file: LICENSE
-  summary: testing feedstock for the regro-cf-autotick-bot
+home: https://github.com/regro/cf-scripts
+license: BSD-3-Clause
+license_family: BSD
+license_file: LICENSE
+summary: testing feedstock for the regro-cf-autotick-bot
 
 extra:
-  recipe-maintainers:
-    - conda-forge-daemon
+recipe-maintainers:
+    - beckermr
+- conda-forge-daemon


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @beckermr as instructed in #221.
Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #221